### PR TITLE
Changed PDGID sed commands by adding whitespace in the pattern

### DIFF
--- a/test/run_svj_tarball.sh
+++ b/test/run_svj_tarball.sh
@@ -5,13 +5,39 @@ $CMSSW_RELEASE_BASE/src/GeneratorInterface/LHEInterface/data/run_generic_tarball
 # convert madgraph ids to pythia ids
 # (also convert a unicode character)
 PDGIDS=(
-5000521,4900101 \
+-5000521,-4900101 \
 # madgraph sign convention is reversed?
 -49001010,4900101 \
 -49001011,4900101 \
 -49001012,4900101 \
 -49001013,4900101 \
 -49001014,4900101 \
+-9000005,-4900001 \
+-9000006,-4900001 \
+-9000007,-4900001 \
+-9000008,-4900001 \
+-9000009,-4900003 \
+-9000010,-4900003 \
+-9000011,-4900003 \
+-9000012,-4900003 \
+-9000013,-4900005 \
+-9000014,-4900005 \
+-9000015,-4900005 \
+-9000016,-4900005 \
+-9000017,-4900002 \
+-9000018,-4900002 \
+-9000019,-4900002 \
+-9000020,-4900002 \
+-9000021,-4900004 \
+-9000022,-4900004 \
+-9000023,-4900004 \
+-9000024,-4900004 \
+-9000025,-4900006 \
+-9000026,-4900006 \
+-9000027,-4900006 \
+-9000028,-4900006 \
+# Same list but ordinary particles now
+5000521,4900101 \
 49001010,-4900101 \
 49001011,-4900101 \
 49001012,-4900101 \
@@ -41,11 +67,13 @@ PDGIDS=(
 9000026,4900006 \
 9000027,4900006 \
 9000028,4900006 \
-'\\x7',a \
 )
 
 for PDGID in ${PDGIDS[@]}; do
-	IDS=()
-	IFS="," read -a IDS <<< "$PDGID"
-	sed -i 's/'"${IDS[0]}"'/'"${IDS[1]}"'/g' cmsgrid_final.lhe
+    IDS=()
+    IFS="," read -a IDS <<< "$PDGID"
+    sed -i 's/'\ "${IDS[0]}"\ '/'\ "${IDS[1]}"\ '/g' cmsgrid_final.lhe
 done
+
+# Fix a unicode character in one of the MadGraph comments
+sed -i 's/\x7/a/g' cmsgrid_final.lhe


### PR DESCRIPTION
Minimal fix to prevent `sed` from replacing pdgid-like numbers in places where they shouldn't be replaced. The one downside of this method is that particles and antiparticles need separate lines now, but at least we avoided regexs. Tested and seems to work.